### PR TITLE
Differentiate calls with no params and calls with empty list param

### DIFF
--- a/include/jsonrpccxx/client.hpp
+++ b/include/jsonrpccxx/client.hpp
@@ -23,7 +23,9 @@ namespace jsonrpccxx {
     virtual ~JsonRpcClient() = default;
 
     template <typename T>
-    T CallMethod(const id_type &id, const std::string &name, const positional_parameter &params = {}) { return call_method(id, name, params).result.get<T>(); }
+    T CallMethod(const id_type &id, const std::string &name) { return call_method(id, name, json::object()).result.get<T>(); }
+     template <typename T>
+    T CallMethod(const id_type &id, const std::string &name, const positional_parameter &params) { return call_method(id, name, params).result.get<T>(); }
     template <typename T>
     T CallMethodNamed(const id_type &id, const std::string &name, const named_parameter &params = {}) { return call_method(id, name, params).result.get<T>(); }
 
@@ -47,6 +49,8 @@ namespace jsonrpccxx {
         j["jsonrpc"] = "2.0";
       }
       if (!params.empty() && !params.is_null()) {
+        j["params"] = params;
+      } else if (params.is_array()) {
         j["params"] = params;
       } else if (v == version::v1) {
         j["params"] = nullptr;

--- a/test/client.cpp
+++ b/test/client.cpp
@@ -18,11 +18,6 @@ struct F {
 
 TEST_CASE_METHOD(F, "v2_method_noparams", TEST_MODULE) {
   c.SetResult(true);
-  clientV2.CallMethod<json>("000-000-000", "some.method_1", {});
-  c.VerifyMethodRequest(version::v2, "some.method_1", "000-000-000");
-  CHECK(!has_key(c.request, "params"));
-
-  c.SetResult(true);
   clientV2.CallMethod<json>("000-000-000", "some.method_1");
   c.VerifyMethodRequest(version::v2, "some.method_1", "000-000-000");
   CHECK(!has_key(c.request, "params"));
@@ -30,14 +25,41 @@ TEST_CASE_METHOD(F, "v2_method_noparams", TEST_MODULE) {
 
 TEST_CASE_METHOD(F, "v1_method_noparams", TEST_MODULE) {
   c.SetResult(true);
-  clientV1.CallMethod<json>(37, "some.method_1", {});
-  c.VerifyMethodRequest(version::v1, "some.method_1", 37);
-  CHECK(has_key_type(c.request, "params", json::value_t::null));
-
-  c.SetResult(true);
   clientV1.CallMethod<json>(37, "some.method_1");
   c.VerifyMethodRequest(version::v1, "some.method_1", 37);
   CHECK(has_key_type(c.request, "params", json::value_t::null));
+}
+
+TEST_CASE_METHOD(F, "v2_method_call_params_empty", TEST_MODULE) {
+  c.SetResult(true);
+  clientV2.CallMethod<json>("1", "some.method_1", {});
+  c.VerifyMethodRequest(version::v2, "some.method_1", "1");
+  CHECK(c.request["params"].is_array());
+  CHECK(c.request["params"].empty());
+  CHECK(c.request["params"].dump() == "[]");
+
+  c.SetResult(true);
+  clientV2.CallMethod<json>("1", "some.method_1", json::array());
+  c.VerifyMethodRequest(version::v2, "some.method_1", "1");
+  CHECK(c.request["params"].is_array());
+  CHECK(c.request["params"].empty());
+  CHECK(c.request["params"].dump() == "[]");
+}
+
+TEST_CASE_METHOD(F, "v1_method_call_params_empty", TEST_MODULE) {
+  c.SetResult(true);
+  clientV1.CallMethod<json>("1", "some.method_1", {});
+  c.VerifyMethodRequest(version::v1, "some.method_1", "1");
+  CHECK(c.request["params"].is_array());
+  CHECK(c.request["params"].empty());
+  CHECK(c.request["params"].dump() == "[]");
+
+  c.SetResult(true);
+  clientV1.CallMethod<json>("1", "some.method_1", json::array());
+  c.VerifyMethodRequest(version::v1, "some.method_1", "1");
+  CHECK(c.request["params"].is_array());
+  CHECK(c.request["params"].empty());
+  CHECK(c.request["params"].dump() == "[]");
 }
 
 TEST_CASE_METHOD(F, "v2_method_call_params_byname", TEST_MODULE) {


### PR DESCRIPTION
This change set proposes adding support for method calls with an empty array of positional arguments.

### Rationale

When issuing a call with positional arguments, the current implementation doesn't differentiate between the calls missing the `params` property completely and the calls with the `params` property containing an empty array. In both cases, the eventual JSON-RPC request won't contain the `params` property.

Unfortunately there are services that require messages with empty `params`, as this behavior does not contradict the official JSON-RPC specification and its handling is at the server's discretion.


### Proposed solution

If `JsonRpcClient::CallMethod` is invoked with two arguments: ID and the method name, generate a request without the `params` property. If `JsonRpcClient::CallMethod` is invoked with three arguments and the params argument is an empty vector, then generate a request with the `params` property containing an empty array.