### PR TITLE
Add support for handles from shared pointers

### DIFF
--- a/include/jsonrpccxx/typemapper.hpp
+++ b/include/jsonrpccxx/typemapper.hpp
@@ -178,6 +178,18 @@ namespace jsonrpccxx {
     };
     return GetHandle(function);
   }
+
+  template <typename T, typename... ParamTypes>
+  NotificationHandle GetHandle(void (T::*method)(ParamTypes...), T &instance) {
+    std::function<void(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> void {
+      return (instance.*method)(std::forward<ParamTypes>(params)...);
+    };
+    return GetHandle(function);
+  }
+
+  //
+  // Mapping for classes as shared pointers
+  //
   template <typename T, typename ReturnType, typename... ParamTypes>
   MethodHandle GetHandle(ReturnType (T::*method)(ParamTypes...), std::shared_ptr<T> &instance) {
     std::function<ReturnType(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> ReturnType {
@@ -189,14 +201,6 @@ namespace jsonrpccxx {
   NotificationHandle GetHandle(void (T::*method)(ParamTypes...), std::shared_ptr<T> &instance) {
     std::function<void(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> void {
       return ((instance.get())->*method)(std::forward<ParamTypes>(params)...);
-    };
-    return GetHandle(function);
-  }
-
-  template <typename T, typename... ParamTypes>
-  NotificationHandle GetHandle(void (T::*method)(ParamTypes...), T &instance) {
-    std::function<void(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> void {
-      return (instance.*method)(std::forward<ParamTypes>(params)...);
     };
     return GetHandle(function);
   }

--- a/include/jsonrpccxx/typemapper.hpp
+++ b/include/jsonrpccxx/typemapper.hpp
@@ -4,6 +4,7 @@
 #include "nlohmann/json.hpp"
 #include <functional>
 #include <limits>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -174,6 +175,20 @@ namespace jsonrpccxx {
   MethodHandle GetHandle(ReturnType (T::*method)(ParamTypes...), T &instance) {
     std::function<ReturnType(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> ReturnType {
       return (instance.*method)(std::forward<ParamTypes>(params)...);
+    };
+    return GetHandle(function);
+  }
+  template <typename T, typename ReturnType, typename... ParamTypes>
+  MethodHandle GetHandle(ReturnType (T::*method)(ParamTypes...), std::shared_ptr<T> &instance) {
+    std::function<ReturnType(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> ReturnType {
+      return ((instance.get())->*method)(std::forward<ParamTypes>(params)...);
+    };
+    return GetHandle(function);
+  }
+  template <typename T, typename... ParamTypes>
+  NotificationHandle GetHandle(void (T::*method)(ParamTypes...), std::shared_ptr<T> &instance) {
+    std::function<void(ParamTypes...)> function = [&instance, method](ParamTypes &&... params) -> void {
+      return ((instance.get())->*method)(std::forward<ParamTypes>(params)...);
     };
     return GetHandle(function);
   }

--- a/test/typemapper.cpp
+++ b/test/typemapper.cpp
@@ -55,6 +55,19 @@ TEST_CASE("test class member explicit binding", TEST_MODULE) {
   CHECK(notifyResult == "Hello world: someone");
 }
 
+TEST_CASE("test class member binding from shared_ptr", TEST_MODULE) {
+  std::shared_ptr<SomeClass> instance;
+  MethodHandle mh = GetHandle(&SomeClass::add, instance);
+  CHECK(mh(R"([3, 4])"_json) == 7);
+
+  notifyResult = "";
+  NotificationHandle mh2 = GetHandle(&SomeClass::notify, instance);
+  CHECK(notifyResult.empty());
+  mh2(R"(["someone"])"_json);
+  CHECK(notifyResult == "Hello world: someone");
+}
+
+
 TEST_CASE("test incorrect params", TEST_MODULE) {
   SomeClass instance;
   MethodHandle mh = GetHandle(&SomeClass::add, instance);


### PR DESCRIPTION
Added templated `GetHandle` functions for instances to be allowed to be passed as shared pointers. 