### PR TITLE
attempt to fix RPC methods expecting floats\doubles could be called with an integral type which would throw an exception (#18)

### DIFF
--- a/include/jsonrpccxx/typemapper.hpp
+++ b/include/jsonrpccxx/typemapper.hpp
@@ -72,6 +72,11 @@ namespace jsonrpccxx {
       if (x.get<long long unsigned>() > std::numeric_limits<T>::max()) {
         throw JsonRpcException(-32602, "invalid parameter: exceeds value range of " + type_name(expectedType), index);
       }
+    }
+    else if ((x.type() == json::value_t::number_unsigned || x.type() == json::value_t::number_integer) && expectedType == json::value_t::number_float) {
+      if (static_cast<long long int>(x.get<double>()) != x.get<long long int>()) {
+        throw JsonRpcException(-32602, "invalid parameter: exceeds value range of " + type_name(expectedType), index);
+      }
     } else if (x.type() != expectedType) {
       throw JsonRpcException(-32602, "invalid parameter: must be " + type_name(expectedType) + ", but is " + type_name(x.type()), index);
     }


### PR DESCRIPTION
This should provide an additional special case for methods which expect float parameters and are being called with an integer. In addition, attempt to catch the case of very large integers (u64), which could not be represented as a double.