### PR TITLE
fix signed compare warning in typemapper.hpp

### DIFF
--- a/include/jsonrpccxx/typemapper.hpp
+++ b/include/jsonrpccxx/typemapper.hpp
@@ -68,7 +68,7 @@ namespace jsonrpccxx {
       if (x.get<long long int>() < 0)
         throw JsonRpcException(invalid_params, "invalid parameter: must be " + type_name(expectedType) + ", but is " + type_name(x.type()), index);
     } else if (x.type() == json::value_t::number_unsigned && expectedType == json::value_t::number_integer) {
-      if (x.get<long long unsigned>() > std::numeric_limits<T>::max()) {
+      if (x.get<long long unsigned>() > (long long unsigned)std::numeric_limits<T>::max()) {
         throw JsonRpcException(invalid_params, "invalid parameter: exceeds value range of " + type_name(expectedType), index);
       }
     }


### PR DESCRIPTION
```typemapper.hpp:71:39: warning: comparison of integer expressions of different signedness: 'long long unsigned int' and 'int' [-Wsign-compare]```

The range check creates a sign compare warning when T is signed. The fix here was to simply cast the result of `std::numeric_limits<T>::max()` to match the long long unsigned type. Which the result should always fit into.