### PR TITLE
fix g++13.2.1 compile error and error_type enum item value reuse

### DIFF
--- a/include/jsonrpccxx/common.hpp
+++ b/include/jsonrpccxx/common.hpp
@@ -14,13 +14,13 @@ namespace jsonrpccxx {
   static inline bool valid_id_not_null(const json &request) { return has_key(request, "id") && (request["id"].is_number() || request["id"].is_string()); }
 
   enum error_type {
-    parse_error = -32700,
-    invalid_request = -32600,
+    parse_error      = -32700,
+    invalid_request  = -32600,
     method_not_found = -32601,
-    invalid_params = -32602,
-    internal_error = -32603,
-    server_error,
-    invalid
+    invalid_params   = -32602,
+    internal_error   = -32603,
+    server_error     = -32604,
+    invalid          = -32500
   };
 
   class JsonRpcException : public std::exception {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -95,7 +95,7 @@ public:
   };
 
   void dirty_notification() { throw std::exception(); }
-  int dirty_method(int a, int b) { to_string(a+b); throw std::exception(); }
+  int dirty_method(int a, int b) { string ignore = to_string(a+b); throw std::exception(); }
   int dirty_method2(int a, int b) { throw (a+b); }
 
   string param_proc;


### PR DESCRIPTION
## fix compile error
```bash
# cmake use g++
$ cmake --system-information | grep "CMAKE_CXX_COMPILER_ID"
CMAKE_CXX_COMPILER_ID "GNU"

$ g++ --version 
g++ (GCC) 13.2.1 20230801
Copyright © 2023 Free Software Foundation, Inc.

$ make clean && make -j8
[ 15%] Building CXX object CMakeFiles/example-warehouse.dir/examples/warehouse/main.cpp.o
[ 15%] Building CXX object CMakeFiles/example-warehouse.dir/examples/warehouse/warehouseapp.cpp.o
[ 23%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/main.cpp.o
[ 30%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/client.cpp.o
[ 38%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/typemapper.cpp.o
[ 46%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/server.cpp.o
[ 53%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/dispatcher.cpp.o
[ 61%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/batchclient.cpp.o
/home/lzh/dev/github/json-rpc-cxx/test/server.cpp: In member function ‘int TestServer::dirty_method(int, int)’:
/home/lzh/dev/github/json-rpc-cxx/test/server.cpp:98:50: 错误：ignoring return value of ‘std::string std::__cxx11::to_string(int)’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
   98 |   int dirty_method(int a, int b) { to_string(a+b); throw std::exception(); }
      |                                                  ^
In file included from /usr/include/c++/13.2.1/string:54,
                 from /usr/include/c++/13.2.1/bits/locale_classes.h:40,
                 from /usr/include/c++/13.2.1/bits/ios_base.h:41,
                 from /usr/include/c++/13.2.1/streambuf:43,
                 from /usr/include/c++/13.2.1/bits/streambuf_iterator.h:35,
                 from /usr/include/c++/13.2.1/iterator:66,
                 from /home/lzh/dev/github/json-rpc-cxx/vendor/nlohmann/json.hpp:53,
                 from /home/lzh/dev/github/json-rpc-cxx/include/jsonrpccxx/common.hpp:2,
                 from /home/lzh/dev/github/json-rpc-cxx/include/jsonrpccxx/server.hpp:3,
                 from /home/lzh/dev/github/json-rpc-cxx/test/testserverconnector.hpp:3,
                 from /home/lzh/dev/github/json-rpc-cxx/test/server.cpp:2:
/usr/include/c++/13.2.1/bits/basic_string.h:4150:3: 附注：在此声明 4150 |   to_string(int __val)
      |   ^~~~~~~~~
[ 69%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/examples/warehouse/warehouseapp.cpp.o
[ 76%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/warehouseapp.cpp.o
[ 84%] Building CXX object CMakeFiles/jsonrpccpp-test.dir/test/common.cpp.o
```

## fix error_type enum item value reuse

**test code**
```c++
// main.cpp
#include <iostream>

enum error_type {
  parse_error = -32700,
  invalid_request = -32600,
  method_not_found = -32601,
  invalid_params = -32602,
  internal_error = -32603,
  server_error,
  invalid
};

int main() {
  std::cout << "parse_error      = " << parse_error      << std::endl;
  std::cout << "invalid_request  = " << invalid_request  << std::endl;
  std::cout << "method_not_found = " << method_not_found << std::endl;
  std::cout << "invalid_params   = " << invalid_params   << std::endl;
  std::cout << "internal_error   = " << internal_error   << std::endl;
  std::cout << "server_error     = " << server_error     << std::endl;
  std::cout << "invalid          = " << invalid          << std::endl;
}
```
**test code execute**
```bash
$ g++ main.cpp -std=c++17 && ./a.out                                                                                                                 ✔ 
parse_error      = -32700
invalid_request  = -32600
method_not_found = -32601
invalid_params   = -32602
internal_error   = -32603
server_error     = -32602
invalid          = -32601
```
we can see the value of `invalid_params` is same as `server_error` and the value of `method_not_found` is same as `invalid`.