### PR TITLE
https://github.com/jsonrpcx/json-rpc-cxx/issues/46

### DIFF
--- a/test/server.cpp
+++ b/test/server.cpp
@@ -95,7 +95,7 @@ public:
   };
 
   void dirty_notification() { throw std::exception(); }
-  int dirty_method(int a, int b) { to_string(a+b); throw std::exception(); }
+  int dirty_method(int a, int b) { auto _ = to_string(a+b); throw std::exception(); }
   int dirty_method2(int a, int b) { throw (a+b); }
 
   string param_proc;


### PR DESCRIPTION
capture (but ignore) the return from std::to_string() to fix warning-as-error ignoring a [[nodiscard]]