### PR TITLE
map std::tuple to json::value_t::array

### DIFF
--- a/include/jsonrpccxx/typemapper.hpp
+++ b/include/jsonrpccxx/typemapper.hpp
@@ -4,6 +4,7 @@
 #include "nlohmann/json.hpp"
 #include <functional>
 #include <limits>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -17,6 +18,10 @@ namespace jsonrpccxx {
 
   template <typename T>
   constexpr json::value_t GetType(type<std::vector<T>>) {
+    return json::value_t::array;
+  }
+  template <typename... T>
+  constexpr json::value_t GetType(type<std::tuple<T...>>) {
     return json::value_t::array;
   }
   template <typename T>


### PR DESCRIPTION
Patch for https://github.com/jsonrpcx/json-rpc-cxx/issues/49